### PR TITLE
Small fix to Android app and JS server to make Realm names match iOS & project name

### DIFF
--- a/Android/app/src/main/java/io/realm/scanner/MainActivity.java
+++ b/Android/app/src/main/java/io/realm/scanner/MainActivity.java
@@ -57,7 +57,7 @@ import io.realm.SyncUser;
 import io.realm.scanner.model.Scan;
 
 public class MainActivity extends AppCompatActivity  implements RealmChangeListener<Scan> {
-    private static final String REALM_URL = "realm://" + BuildConfig.OBJECT_SERVER_IP + ":9080/~/textscanner";
+    private static final String REALM_URL = "realm://" + BuildConfig.OBJECT_SERVER_IP + ":9080/~/scanner";
     private static final String AUTH_URL = "http://" + BuildConfig.OBJECT_SERVER_IP + ":9080/auth";
     private static final String ID = "scanner@realm.io";
     private static final String PASSWORD = "password";

--- a/Server/index.js
+++ b/Server/index.js
@@ -18,7 +18,7 @@ var SERVER_URL = 'realm://127.0.0.1:9080';
 
 // The path used by the global notifier to listen for changes across all
 // Realms that match.
-var NOTIFIER_PATH = ".*/textscanner";
+var NOTIFIER_PATH = ".*/scanner";
 
 /*
 Common status text strings


### PR DESCRIPTION
- Change name of realm in server app & the Android app from “textscanner” to  “scanner” to match both the name of the project and the Realm name used by iOS app.